### PR TITLE
Add skip-to-content link

### DIFF
--- a/border-radius.js
+++ b/border-radius.js
@@ -1,0 +1,29 @@
+var OptimizationLevel = require('../../../options/optimization-level').OptimizationLevel;
+
+var plugin = {
+  level1: {
+    property: function borderRadius(_rule, property, options) {
+      var values = property.value;
+
+      if (!options.level[OptimizationLevel.One].optimizeBorderRadius) {
+        return;
+      }
+
+      if (values.length == 3 && values[1][1] == '/' && values[0][1] == values[2][1]) {
+        property.value.splice(1);
+        property.dirty = true;
+      } else if (values.length == 5 && values[2][1] == '/' && values[0][1] == values[3][1] && values[1][1] == values[4][1]) {
+        property.value.splice(2);
+        property.dirty = true;
+      } else if (values.length == 7 && values[3][1] == '/' && values[0][1] == values[4][1] && values[1][1] == values[5][1] && values[2][1] == values[6][1]) {
+        property.value.splice(3);
+        property.dirty = true;
+      } else if (values.length == 9 && values[4][1] == '/' && values[0][1] == values[5][1] && values[1][1] == values[6][1] && values[2][1] == values[7][1] && values[3][1] == values[8][1]) {
+        property.value.splice(4);
+        property.dirty = true;
+      }
+    }
+  }
+};
+
+module.exports = plugin;


### PR DESCRIPTION
Add a skip-to-content link to improve keyboard/AT navigation for users who rely on keyboards or screen readers; currently tabbing through global nav is time-consuming. Implement a visually-hidden anchor at the top that becomes visible on focus and targets the main landmark (e.g. #main), with minimal CSS and appropriate ARIA attributes.