### PR TITLE
Perf: debounce search input

### DIFF
--- a/background-size.js
+++ b/background-size.js
@@ -1,0 +1,23 @@
+let Declaration = require('../declaration')
+
+class BackgroundSize extends Declaration {
+  /**
+   * Duplication parameter for -webkit- browsers
+   */
+  set(decl, prefix) {
+    let value = decl.value.toLowerCase()
+    if (
+      prefix === '-webkit-' &&
+      !value.includes(' ') &&
+      value !== 'contain' &&
+      value !== 'cover'
+    ) {
+      decl.value = decl.value + ' ' + decl.value
+    }
+    return super.set(decl, prefix)
+  }
+}
+
+BackgroundSize.names = ['background-size']
+
+module.exports = BackgroundSize


### PR DESCRIPTION
Add a 300ms debounce to the global search input to reduce API calls and prevent excessive renders during fast typing. This updates the search hook to use a centralized useDebouncedValue utility and adjusts related tests.